### PR TITLE
Implement outer/inner toggle for Shadow settings

### DIFF
--- a/src/CodeGen.elm
+++ b/src/CodeGen.elm
@@ -607,14 +607,21 @@ emitShadow value attrs =
         attrs
 
     else
-        G.apply
-            [ G.fqFun borderModule "shadow"
-            , G.record
+        let 
+            record = G.record
                 [ ( "offset", G.tuple [ G.float value.offsetX, G.float value.offsetY ] )
                 , ( "size", G.float value.size )
                 , ( "blur", G.float value.blur )
                 , ( "color", emitColor value.color )
                 ]
+        in
+        G.apply
+            [ case value.type_ of
+                Inner ->
+                    G.fqFun borderModule "innerShadow"
+                Outer ->
+                    G.fqFun borderModule "shadow"
+            , record
             ]
             :: attrs
 

--- a/src/Document.elm
+++ b/src/Document.elm
@@ -41,6 +41,7 @@ module Document exposing
     , applyPosition
     , applyShadow
     , applyShadowColor
+    , applyShadowType
     , applySpacing
     , applyText
     , applyTextAlign
@@ -90,7 +91,7 @@ import Style.Border as Border exposing (BorderCorner, BorderStyle(..), BorderWid
 import Style.Font as Font exposing (..)
 import Style.Input as Input exposing (LabelPosition(..))
 import Style.Layout as Layout exposing (..)
-import Style.Shadow as Shadow exposing (Shadow)
+import Style.Shadow as Shadow exposing (Shadow, ShadowType)
 import Style.Theme as Theme exposing (Theme)
 import Time exposing (Posix)
 import Tree as T exposing (Tree)
@@ -1130,6 +1131,11 @@ applyShadowColor value zipper =
             Css.stringToColor value
     in
     Zipper.mapLabel (\node -> Shadow.setShadow (Shadow.setColor value_ node.shadow) node) zipper
+
+
+applyShadowType : ShadowType -> Zipper Node -> Zipper Node
+applyShadowType value zipper =
+    Zipper.mapLabel (\node -> Shadow.setShadow (Shadow.setType value node.shadow) node) zipper
 
 
 applyLabelPosition : LabelPosition -> Zipper Node -> Zipper Node

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -470,6 +470,9 @@ update msg model =
         ShadowColorChanged value ->
             applyChange model Document.applyShadowColor value
 
+        ShadowTypeChanged value ->
+            applyChange model Document.applyShadowType value
+
         FontColorChanged value ->
             applyChange model Document.applyFontColor value
 

--- a/src/Model.elm
+++ b/src/Model.elm
@@ -33,6 +33,7 @@ import Style.Background as Background exposing (Background)
 import Style.Font as Font exposing (..)
 import Style.Input as Input exposing (LabelPosition(..))
 import Style.Layout as Layout exposing (..)
+import Style.Shadow as Shadow exposing (..)
 import Style.Theme as Theme exposing (Theme)
 import Time exposing (Posix)
 import Tree exposing (Tree)
@@ -77,6 +78,7 @@ type Msg
     | BorderColorChanged String
     | BorderStyleChanged BorderStyle
     | ShadowColorChanged String
+    | ShadowTypeChanged ShadowType
     | LabelPositionChanged LabelPosition
     | FieldEditingStarted Field String
     | FieldEditingConfirmed

--- a/src/Style/Shadow.elm
+++ b/src/Style/Shadow.elm
@@ -2,12 +2,15 @@ module Style.Shadow exposing
     ( Shadow
     , ShadowType(..)
     , none
+    , isInner
+    , isOuter
     , setBlur
     , setColor
     , setOffsetX
     , setOffsetY
     , setShadow
     , setSize
+    , setType
     )
 
 {-| Shadow properties.
@@ -34,6 +37,24 @@ type alias Shadow =
 
 none =
     Shadow 0 0 0 0 Palette.black Outer
+
+
+isInner value =
+    case value of
+        Inner ->
+            True
+
+        _ ->
+            False
+
+
+isOuter value =
+    case value of
+        Outer ->
+            True
+
+        _ ->
+            False
 
 
 setShadow : Shadow -> { a | shadow : Shadow } -> { a | shadow : Shadow }
@@ -64,3 +85,8 @@ setSize value record =
 setColor : Color -> Shadow -> Shadow
 setColor value record =
     { record | color = value }
+
+
+setType : ShadowType -> Shadow -> Shadow
+setType value record =
+    { record | type_ = value }

--- a/src/Views/Inspector.elm
+++ b/src/Views/Inspector.elm
@@ -24,6 +24,7 @@ import Style.Border as Border exposing (BorderStyle(..))
 import Style.Font as Font exposing (..)
 import Style.Input as Input exposing (..)
 import Style.Layout as Layout exposing (..)
+import Style.Shadow as Shadow
 import Style.Theme as Theme
 import Tree as T exposing (Tree)
 import Tree.Zipper as Zipper exposing (Zipper)
@@ -823,6 +824,26 @@ shadowView model { shadow } =
                 ]
             ]
         , colorView model (Just shadow.color) ShadowColorField ShadowColorChanged
+        , H.div [ A.class "btn-group w-100 mb-2", A.attribute "role" "group" ]
+            [ H.button
+                [ A.classList
+                    [ ( "btn btn-outline-secondary btn-sm", True )
+                    , ( "active", Shadow.isInner shadow.type_ )
+                    ]
+                , E.onClick (ShadowTypeChanged Shadow.Inner)
+                , A.type_ "button"
+                ]
+                [ H.text "Inner" ]
+            , H.button
+                [ A.classList
+                    [ ( "btn btn-outline-secondary btn-sm", True )
+                    , ( "active", Shadow.isOuter shadow.type_ )
+                    ]
+                , E.onClick (ShadowTypeChanged Shadow.Outer)
+                , A.type_ "button"
+                ]
+                [ H.text "Outer" ]
+            ]
         ]
 
 


### PR DESCRIPTION
I had a stab at issue #31 ,
The PR includes the Toggle button and code generation using ```Border.innerShadow```, but left out the negative offset thing for now.
Please let me know what you  think.
